### PR TITLE
Add class instance counting and support for negative samples in datas…

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ uv run morpheus <input_directory> <output_directory> [options]
 | `--flip-v` | | Vertical flip augmentation* | False |
 | `--gaussian-blur` | | Apply Gaussian blur* | False |
 | `--in-memory` | | Load all images to RAM (faster) | False |
+| `--include-negatives` | | Include images without XML as negative samples | False |
 
 *Requires `--multiply > 1`
 
@@ -79,6 +80,23 @@ When augmentations are enabled (with `--multiply > 1`), the tool randomly applie
 - **Horizontal Flip** (`--flip-h`): Flips the image horizontally and adjusts bounding boxes accordingly
 - **Vertical Flip** (`--flip-v`): Flips the image vertically and adjusts bounding boxes accordingly  
 - **Gaussian Blur** (`--gaussian-blur`): Applies Gaussian blur with a randomly selected kernel size (3, 5, or 7) to add slight blur, which can help improve model robustness to image quality variations
+
+### Negative Samples
+
+When using annotation tools like LabelIMG, images that contain no objects of interest receive no `.xml` annotation file. By default, Morpheus skips these images. However, including them as **negative samples** (images with empty label files) can significantly improve model performance by teaching the model what "nothing" looks like — reducing false positives like phantom detections on empty conveyor belts.
+
+Use the `--include-negatives` flag to include these unannotated images in your dataset:
+
+```bash
+uv run morpheus ./raw_data ./yolo_dataset --include-negatives
+```
+
+When enabled, Morpheus will:
+1. Detect images without a matching `.xml` file
+2. Read image dimensions and generate a LabelIMG-compatible empty `.xml` annotation
+3. Include the image in the dataset with an empty `.txt` label file (no bounding boxes)
+
+The tool prints a summary showing how many labeled vs. negative images were matched.
 
 ### Duplicate Filename Handling
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -101,6 +101,7 @@ def arguments(tmp_path):
         multiply=1,
         augment=False,
         in_memory=False,
+        include_negatives=False,
     )
 
 
@@ -265,6 +266,10 @@ def test_augment(images, arguments):
 @patch(
     "morpheus.dataset.get_class_names",
     new=Mock(return_value=constants.CLASS_NAMES),
+)
+@patch(
+    "morpheus.dataset.count_class_instances",
+    new=Mock(),
 )
 def test_main(arguments, images):
     """Test the main function"""


### PR DESCRIPTION
This pull request adds support for including negative samples (images without XML annotations) in the dataset, improves dataset statistics reporting, and enhances the matching of images to labels. The changes affect both the CLI interface and the dataset processing logic, and update documentation accordingly.

**Negative sample support and dataset statistics:**

* Added a `--include-negatives` CLI flag to include images without XML annotations as negative samples. When enabled, the tool generates empty XML files for these images and includes them in the dataset, helping to reduce false positives by teaching the model what "nothing" looks like. The README was updated with usage instructions and an explanation of the feature. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R84-R100) [[3]](diffhunk://#diff-31fb55699cb4481dd0848d43e5ca156eef430f8784c7aae719bdfa30198e11caR526-R530)
* Updated `match_images_to_label_files` in `utils/general.py` to support the `include_negatives` option: it now detects images without XML files, generates LabelIMG-compatible empty XML annotations, and includes them as negative samples. The function prints a summary of labeled versus negative images. [[1]](diffhunk://#diff-dd425673dc44b64697acc887bb7abefec7ca7d92cf434d7ac9a6d69a8268f47aL38-R102) [[2]](diffhunk://#diff-dd425673dc44b64697acc887bb7abefec7ca7d92cf434d7ac9a6d69a8268f47aR118-L62) [[3]](diffhunk://#diff-dd425673dc44b64697acc887bb7abefec7ca7d92cf434d7ac9a6d69a8268f47aR146-R176)
* Added the `_indent_xml` and `_write_empty_xml` helper functions to generate properly formatted empty XML files for negative samples.

**Dataset statistics reporting:**

* Added a `count_class_instances` function to print statistics about the dataset: total unlabeled images and per-class instance counts. This function is now called in the main dataset processing flow. [[1]](diffhunk://#diff-31fb55699cb4481dd0848d43e5ca156eef430f8784c7aae719bdfa30198e11caR283-R305) [[2]](diffhunk://#diff-31fb55699cb4481dd0848d43e5ca156eef430f8784c7aae719bdfa30198e11caL295-R326)

**Testing and compatibility:**

* Updated tests and argument parsing to support the new `include_negatives` flag and to mock the new statistics function. [[1]](diffhunk://#diff-26199baaf391361625bd6773b9df4ed2677df4680a9650d2731510adec4898eaR104) [[2]](diffhunk://#diff-26199baaf391361625bd6773b9df4ed2677df4680a9650d2731510adec4898eaR270-R273)

These changes make it easier to train models with negative samples and provide better insight into dataset composition.