### PR TITLE
Add functionality to remap all classes to a single name

### DIFF
--- a/morpheus/dataset.py
+++ b/morpheus/dataset.py
@@ -320,11 +320,29 @@ def remap_classes(
                                         a list of MorpheusImage objects.
 
     """
-    print(
-        "The following class names were found within the dataset,"
-        "would you like to re-map any of them?"
-    )
+    print("The following class names were found within the dataset:")
     print(class_names)
+
+    if len(class_names) > 1:
+        while True:
+            remap_all_input = input(
+                "Would you like to remap all classes to a single name? (y/n): "
+            ).lower()
+            if remap_all_input in ["yes", "y", "no", "n"]:
+                break
+            print(const.INVALID_INPUT)
+        if remap_all_input in ["yes", "y"]:
+            new_name = input("Enter the class name: ").strip()
+            if new_name:
+                old_count = len(class_names)
+                for image in images:
+                    for label in image.labels:
+                        label.name = new_name
+                class_names = [new_name]
+                print(f"Remapped {old_count} classes -> '{new_name}'")
+                return class_names, images
+
+    print("Would you like to re-map any of them?")
     while True:
         user_input = input("Enter 'yes' or 'no' (y/n): ").lower()
         if user_input in ["yes", "no", "y", "n"]:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -478,7 +478,9 @@ def test_parse_args(tmp_path):
     "builtins.input",
     new=Mock(
         side_effect=[
-            "n",  # prompt to remap classes - no
+            "n",  # remap all to single name - no (first call)
+            "n",  # prompt to remap classes - no (first call)
+            "n",  # remap all to single name - no (second call)
             "test_bad_input",  # prompt to remap classes - bad input
             "y",  # prompt to remap classes - yes
             "test_bad_input",  # prompt to remap more classes - bad input


### PR DESCRIPTION
This pull request enhances the user experience when remapping class names in datasets by adding a new prompt to optionally remap all classes to a single name, and updates the related test to accommodate this new interaction.

Improvements to class remapping workflow:

* Added a prompt in `remap_classes` (in `morpheus/dataset.py`) that allows users to remap all classes to a single name in one step if multiple classes are detected. If the user chooses this option, all labels are updated accordingly and the function exits early.

Testing updates:

* Updated the `test_parse_args` test (in `tests/test_dataset.py`) to mock the new user prompts introduced by the remap-all-classes feature, ensuring the test accurately reflects the new input flow.