### PR TITLE
Add --no-test flag to skip test split in dataset generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ uv run morpheus <input_directory> <output_directory> [options]
 | `--gaussian-blur` | | Apply Gaussian blur* | False |
 | `--in-memory` | | Load all images to RAM (faster) | False |
 | `--include-negatives` | | Include images without XML as negative samples | False |
+| `--no-test` | | Skip test split; distribute to train/valid only | False |
 
 *Requires `--multiply > 1`
 

--- a/morpheus/dataset.py
+++ b/morpheus/dataset.py
@@ -316,7 +316,6 @@ def count_class_instances(images: List[MorpheusImage]) -> None:
         print("No labeled instances found in dataset.")
 
 
-
 def main(input_directory: Path, output_directory: Path, args=None):
     """Main function
 

--- a/morpheus/dataset.py
+++ b/morpheus/dataset.py
@@ -173,6 +173,13 @@ def generate_dataset(
     assert round(train_ratio + val_ratio + test_ratio, 5) == 1.0, (
         "Split Ratios should sum up to 1"
     )
+
+    if args.no_test:
+        total = train_ratio + val_ratio
+        train_ratio = train_ratio / total
+        val_ratio = val_ratio / total
+        test_ratio = 0
+
     if multiply > 1:
         images = multiply_files(images, multiply)
     total_images = len(images)
@@ -183,10 +190,16 @@ def generate_dataset(
     random.shuffle(images)
 
     train_data = images[:train_end]
-    val_data = images[train_end:val_end]
-    test_data = images[val_end:]
+    if args.no_test:
+        val_data = images[train_end:]
+        test_data = []
+    else:
+        val_data = images[train_end:val_end]
+        test_data = images[val_end:]
 
-    splits = [("train", train_data), ("valid", val_data), ("test", test_data)]
+    splits = [("train", train_data), ("valid", val_data)]
+    if test_data:
+        splits.append(("test", test_data))
 
     # Load all images in memory if requested
     if args.in_memory:
@@ -246,7 +259,8 @@ def generate_dataset(
     with open(output_directory / "data.yaml", "w") as outfile:
         outfile.write("train: ../train/images\n")
         outfile.write("val: ../valid/images\n")
-        outfile.write("test: ../test/images\n")
+        if test_data:
+            outfile.write("test: ../test/images\n")
         outfile.write(f"nc: {len(class_names)}\n")
         outfile.write(
             "names: [" + ", ".join(f"'{name}'" for name in class_names) + "]\n"
@@ -545,6 +559,12 @@ def parse_args(arguments):
         "--include-negatives",
         action="store_true",
         help="Include images without XML annotations as negative samples (empty labels)",
+    )
+    parser.add_argument(
+        "--no-test",
+        action="store_true",
+        default=False,
+        help="Skip test split; distribute all images to train and valid only",
     )
     arguments = parser.parse_args(arguments)
     if arguments.flip_h or arguments.flip_v or arguments.gaussian_blur:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -102,6 +102,7 @@ def arguments(tmp_path):
         augment=False,
         in_memory=False,
         include_negatives=False,
+        no_test=False,
     )
 
 
@@ -373,6 +374,32 @@ def test_generate_dataset_with_in_memory(tmp_path, arguments):
     MorpheusImage.write_image_to_disk.assert_called_with(keep_in_memory=True)
 
 
+@patch("models.dataclasses.MorpheusImage.resize_image", new=Mock())
+@patch("models.dataclasses.MorpheusImage.write_image_to_disk", new=Mock())
+def test_generate_dataset_no_test(tmp_path, arguments):
+    """Test generate_dataset with --no-test skips the test split."""
+    arguments.no_test = True
+    matched_images = get_mocked_morpheus_images(tmp_path)
+    matched_images.sort(key=lambda x: x.name)
+    shutil.copy2 = Mock()
+    output_directory = tmp_path / "output"
+
+    generate_dataset(output_directory, constants.CLASS_NAMES, matched_images, arguments)
+
+    # train and valid dirs should exist
+    assert (output_directory / "train" / "images").exists()
+    assert (output_directory / "valid" / "images").exists()
+    # test dir should NOT exist
+    assert not (output_directory / "test").exists()
+
+    # data.yaml should not contain test line
+    with open(output_directory / constants.DATA_YAML_FILENAME, "r") as file:
+        content = file.read()
+    assert constants.DATA_TRAIN_YAML_CONTENT in content
+    assert constants.DATA_VAL_YAML_CONTENT in content
+    assert "test:" not in content
+
+
 def test_main_with_memory_abort(arguments, images):
     """Test main function when user aborts due to memory constraints."""
     arguments.in_memory = True
@@ -472,6 +499,13 @@ def test_parse_args(tmp_path):
     assert parsed_args.input_directory == in_dir
     assert parsed_args.output_directory == out_dir
     assert parsed_args.in_memory is True
+    # test with no-test argument
+    args = main_args
+    args += ["--no-test"]
+    parsed_args = parse_args(args)
+    assert parsed_args.input_directory == in_dir
+    assert parsed_args.output_directory == out_dir
+    assert parsed_args.no_test is True
 
 
 # @patch("morpheus.dataset.remap_class", new=Mock(return_value="car"))

--- a/utils/general.py
+++ b/utils/general.py
@@ -60,7 +60,9 @@ def _indent_xml(elem, level=0):
         elem.tail = "\n"
 
 
-def _write_empty_xml(xml_path: Path, image_path: Path, width: int, height: int, depth: int):
+def _write_empty_xml(
+    xml_path: Path, image_path: Path, width: int, height: int, depth: int
+):
     """Write a LabelIMG-compatible XML annotation file with no objects.
 
     Args:


### PR DESCRIPTION
This pull request adds support for skipping the test split when generating datasets, distributing all images between train and validation sets only. It introduces a new `--no-test` command-line option, updates the dataset generation logic, and adds corresponding tests and documentation.

**New Feature: Skip Test Split**
* Added a `--no-test` flag to the CLI, allowing users to skip the test split and allocate all images to train and validation splits (`README.md`, `morpheus/dataset.py`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50) [[2]](diffhunk://#diff-31fb55699cb4481dd0848d43e5ca156eef430f8784c7aae719bdfa30198e11caR530-R535).